### PR TITLE
Add missing property declarations

### DIFF
--- a/src/Box/View/BoxViewException.php
+++ b/src/Box/View/BoxViewException.php
@@ -7,4 +7,8 @@ namespace Box\View;
  */
 class BoxViewException extends \Exception
 {
+    /**
+     * @var string
+     */
+    public $errorCode;
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,6 +5,11 @@ use \Mockery as m;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Box\View\Client
+     */
+    private $client;
+
     public function setUp()
     {
         $apiKey       = 'abc123';

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -5,6 +5,16 @@ use \Mockery as m;
 
 class DocumentTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Box\View\Client
+     */
+    private $client;
+
+    /**
+     * @var \Mockery\MockInterface
+     */
+    private $requestMock;
+
     public function setUp()
     {
         $apiKey       = 'abc123';

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -5,6 +5,16 @@ use \Mockery as m;
 
 class SessionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Box\View\Client
+     */
+    private $client;
+
+    /**
+     * @var \Mockery\MockInterface
+     */
+    private $requestMock;
+
     public function setUp()
     {
         $apiKey       = 'abc123';


### PR DESCRIPTION
Having properties defined in the source rather than dynamically makes it easier for developers using them. It also improves things for PHP as dynamic properties are stored in a less efficient way (because they are not known at compile time and are specific to instances rather than being defined for the class)