### PR TITLE
Fix class references in the phpdoc to be valid

### DIFF
--- a/src/Box/View/Base.php
+++ b/src/Box/View/Base.php
@@ -14,7 +14,7 @@ abstract class Base
 
     /**
      * The client instance to make requests from.
-     * @var Box\View\Client
+     * @var \Box\View\Client
      */
     protected $client;
 
@@ -22,7 +22,7 @@ abstract class Base
      * Take a date in almost any format, and return a date string that is
      * formatted as an RFC 3339 timestamp.
      *
-     * @param string|DateTime $date A date string in almost any format, or a
+     * @param string|\DateTime $date A date string in almost any format, or a
      *                              DateTime object.
      *
      * @return string An RFC 3339 timestamp.
@@ -43,7 +43,7 @@ abstract class Base
      * @param string|null $message The error message.
      *
      * @return void
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     protected static function error($error, $message = null)
     {
@@ -56,7 +56,7 @@ abstract class Base
     /**
      * Send a new request to the API.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param string $requestPath The path to add after the base path.
      * @param array|null $getParams Optional. An associative array of GET params
      *                              to be added to the URL.
@@ -66,8 +66,8 @@ abstract class Base
      *                                   request options that may modify the way
      *                                   the request is made.
      *
-     * @return array|string The response is pass-thru from Box\View\Request.
-     * @throws Box\View\BoxViewException
+     * @return array|string The response is pass-through from Box\View\Request.
+     * @throws \Box\View\BoxViewException
      */
     protected static function request(
         $client,

--- a/src/Box/View/Client.php
+++ b/src/Box/View/Client.php
@@ -44,7 +44,7 @@ class Client
      *
      * @return array An array containing document instances matching the
      *               request.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function findDocuments($params = [])
     {
@@ -67,8 +67,8 @@ class Client
      *
      * @param string $id The document ID.
      *
-     * @return Box\View\Document A document instance using data from the API.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A document instance using data from the API.
+     * @throws \Box\View\BoxViewException
      */
     public function getDocument($id)
     {
@@ -129,8 +129,8 @@ class Client
      *                               of the file that doesn't use SVG, for users
      *                               with browsers that don't support SVG?
      *
-     * @return Box\View\Document A new document instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A new document instance.
+     * @throws \Box\View\BoxViewException
      */
     public function uploadFile($file, $params = [])
     {
@@ -155,8 +155,8 @@ class Client
      *                               of the file that doesn't use SVG, for users
      *                               with browsers that don't support SVG?
      *
-     * @return Box\View\Document A new document instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A new document instance.
+     * @throws \Box\View\BoxViewException
      */
     public function uploadUrl($url, $params = [])
     {

--- a/src/Box/View/Document.php
+++ b/src/Box/View/Document.php
@@ -61,7 +61,7 @@ class Document extends Base
     /**
      * Instantiate the document.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param array $data An associative array to instantiate the object with.
      *                    Use the following values:
      *                      - string 'id' The document ID.
@@ -135,8 +135,8 @@ class Document extends Base
      *                             - bool|null 'isTextSelectable' Should the
      *                               user be allowed to select text?
      *
-     * @return Box\View\Session A new session instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Session A new session instance.
+     * @throws \Box\View\BoxViewException
      */
     public function createSession($params = [])
     {
@@ -147,7 +147,7 @@ class Document extends Base
      * Delete a file.
      *
      * @return bool Was the file deleted?
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function delete()
     {
@@ -170,7 +170,7 @@ class Document extends Base
      *                               downloaded using the original extension.
      *
      * @return string The contents of the downloaded file.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function download($extension = null)
     {
@@ -188,7 +188,7 @@ class Document extends Base
      * @param int $height The height of the thumbnail in pixels.
      *
      * @return string The contents of the downloaded thumbnail.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function thumbnail($width, $height)
     {
@@ -210,7 +210,7 @@ class Document extends Base
      *                      time.
      *
      * @return bool Was the file updated?
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function update($fields)
     {
@@ -232,7 +232,7 @@ class Document extends Base
     /**
      * Get a list of all documents that meet the provided criteria.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param array|null $params Optional. An associative array to filter the
      *                           list of all documents uploaded. None are
      *                           necessary; all are optional. Use the following
@@ -246,7 +246,7 @@ class Document extends Base
      *
      * @return array An array containing document instances matching the
      *               request.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public static function find($client, $params = [])
     {
@@ -286,11 +286,11 @@ class Document extends Base
      * Create a new document instance by ID, and load it with values requested
      * from the API.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param string $id The document ID.
      *
-     * @return Box\View\Document A document instance using data from the API.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A document instance using data from the API.
+     * @throws \Box\View\BoxViewException
      */
     public static function get($client, $id)
     {
@@ -305,7 +305,7 @@ class Document extends Base
     /**
      * Upload a local file and return a new document instance.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param resource $file The file resource to upload.
      * @param array|null $params Optional. An associative array of options
      *                           relating to the file upload. None are
@@ -321,8 +321,8 @@ class Document extends Base
      *                               of the file that doesn't use SVG, for users
      *                               with browsers that don't support SVG?
      *
-     * @return Box\View\Document A new document instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A new document instance.
+     * @throws \Box\View\BoxViewException
      */
     public static function uploadFile($client, $file, $params = [])
     {
@@ -340,7 +340,7 @@ class Document extends Base
     /**
      * Upload a file by URL and return a new document instance.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param string $url The URL of the file to upload.
      * @param array|null $params Optional. An associative array of options
      *                           relating to the file upload. None are
@@ -356,8 +356,8 @@ class Document extends Base
      *                               of the file that doesn't use SVG, for users
      *                               with browsers that don't support SVG?
      *
-     * @return Box\View\Document A new document instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A new document instance.
+     * @throws \Box\View\BoxViewException
      */
     public static function uploadUrl($client, $url, $params = [])
     {
@@ -397,7 +397,7 @@ class Document extends Base
      * more specific than this one, and know how to handle upload by URL and
      * upload from filesystem.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param array|null $params An associative array of options relating to the
      *                           file upload. Pass-thru from the other upload
      *                           functions.
@@ -406,8 +406,8 @@ class Document extends Base
      * @param array|null $options An associative array of request options that
      *                            may modify the way the request is made.
      *
-     * @return Box\View\Document A new document instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Document A new document instance.
+     * @throws \Box\View\BoxViewException
      */
     private static function upload(
         $client,

--- a/src/Box/View/Request.php
+++ b/src/Box/View/Request.php
@@ -96,7 +96,7 @@ class Request
      * @return array|string The response array is usually converted from JSON,
      *                      but sometimes we just return the raw response from
      *                      the server.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function send(
         $path,
@@ -155,13 +155,13 @@ class Request
      * @param string $error An error code representing the error
      *                      (use_underscore_separators).
      * @param string|null $message The error message.
-     * @param GuzzleHttp\Message\Request|null $request Optional. The Guzzle
+     * @param \GuzzleHttp\Message\RequestInterface|null $request Optional. The Guzzle
      *                                                 request object.
-     * @param GuzzleHttp\Message\Response|null $response Optional. The Guzzle
+     * @param \GuzzleHttp\Message\ResponseInterface|null $response Optional. The Guzzle
      *                                                   response object.
      *
      * @return void
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     protected static function error(
         $error,
@@ -194,13 +194,13 @@ class Request
      * Execute a request to the server and return the response, while retrying
      * based on any Retry-After headers that are sent back.
      *
-     * @param GuzzleHttp\Client $guzzle The Guzzle instance to use.
-     * @param GuzzleHttp\Message\Request $request The request to send, and
+     * @param \GuzzleHttp\Client $guzzle The Guzzle instance to use.
+     * @param \GuzzleHttp\Message\RequestInterface $request The request to send, and
      *                                            possibly retry.
      * @param int $timeout The maximum number of seconds to retry for.
      *
-     * @return GuzzleHttp\Message\Response The Guzzle response object.
-     * @throws GuzzleHttp\Exception\RequestException
+     * @return \GuzzleHttp\Message\ResponseInterface The Guzzle response object.
+     * @throws \GuzzleHttp\Exception\RequestException
      */
     private function execute($guzzle, $request, $timeout)
     {
@@ -233,7 +233,7 @@ class Request
      *
      * @param string|null $host Optional. The host to use in the base URL.
      *
-     * @return GuzzleHttp\Client A new Guzzle instance.
+     * @return \GuzzleHttp\Client A new Guzzle instance.
      */
     private function getGuzzleInstance($host = null)
     {
@@ -281,10 +281,10 @@ class Request
     /**
      * Handle a request error from Guzzle.
      *
-     * @param GuzzleHttp\Exception\RequestException e The Guzzle request error.
+     * @param \GuzzleHttp\Exception\RequestException e The Guzzle request error.
      *
      * @return void
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     private static function handleRequestError($e)
     {
@@ -307,14 +307,14 @@ class Request
      * checking anything. JSON responses are decoded and then checked for
      * any errors.
      *
-     * @param GuzzleHttp\Message\Response $response The Guzzle response object.
+     * @param \GuzzleHttp\Message\ResponseInterface $response The Guzzle response object.
      * @param bool $isRawResponse Do we want to return the raw response, or
      *                            process as JSON?
-     * @param GuzzleHttp\Message\Request The Guzzle request object.
+     * @param \GuzzleHttp\Message\RequestInterface The Guzzle request object.
      *
      * @return array|string An array decoded from JSON, or the raw response from
      *                      the server.
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     private static function handleResponse($response, $isRawResponse, $request)
     {

--- a/src/Box/View/Session.php
+++ b/src/Box/View/Session.php
@@ -17,7 +17,7 @@ class Session extends Base
 
     /**
      * The document that created this session.
-     * @var Box\View\Document
+     * @var \Box\View\Document
      */
     private $document;
 
@@ -46,7 +46,7 @@ class Session extends Base
     /**
      * Instantiate the session.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param array $data An associative array to instantiate the object with.
      *                    Use the following values:
      *                      - Box\View\Document 'document' The document the
@@ -68,7 +68,7 @@ class Session extends Base
     /**
      * Get the document the session was created for.
      *
-     * @return Box\View\Document The document the session was created for.
+     * @return \Box\View\Document The document the session was created for.
      */
     public function document()
     {
@@ -108,7 +108,7 @@ class Session extends Base
     /**
      * Get the session realtime URL.
      *
-     * @return string The session realtimes URL.
+     * @return string The session realtime URL.
      */
     public function realtimeUrl()
     {
@@ -129,7 +129,7 @@ class Session extends Base
      * Delete a session.
      *
      * @return bool Was the session deleted?
-     * @throws Box\View\BoxViewException
+     * @throws \Box\View\BoxViewException
      */
     public function delete()
     {
@@ -146,7 +146,7 @@ class Session extends Base
     /**
      * Create a session for a specific document by ID.
      *
-     * @param Box\View\Client $client The client instance to make requests from.
+     * @param \Box\View\Client $client The client instance to make requests from.
      * @param string $id The ID of the document to create a session for.
      * @param array|null $params Optional. An associative array of options
      *                           relating to the new session. None are
@@ -161,8 +161,8 @@ class Session extends Base
      *                             - bool|null 'isTextSelectable' Should the
      *                               user be allowed to select text?
      *
-     * @return Box\View\Session A new session instance.
-     * @throws Box\View\BoxViewException
+     * @return \Box\View\Session A new session instance.
+     * @throws \Box\View\BoxViewException
      */
     public static function create($client, $id, $params = [])
     {


### PR DESCRIPTION
This makes the life much easier for anyone using an IDE, as it will be able to resolve the return values properly and so to continue providing autocompletion.