### PR TITLE
Fix the handling of guzzle errors

### DIFF
--- a/src/Box/View/Request.php
+++ b/src/Box/View/Request.php
@@ -291,12 +291,16 @@ class Request
         $request  = $e->getRequest();
         $response = $e->getResponse();
 
-        $error   = static::handleHttpError($response->getStatusCode());
+        $error = null;
         $message = 'Server error';
+
+        if (null !== $response) {
+            $error   = static::handleHttpError($response->getStatusCode());
+        }
 
         if (!$error) {
             $error   = static::GUZZLE_ERROR;
-            $message = 'Guzzle error';
+            $message = sprintf('Guzzle error (%s)', $e->getMessage());
         }
 
         static::error($error, $message, $request, $response);


### PR DESCRIPTION
Guzzle errors don't always have a Response in them depending on when the exception occurs. These cases were triggering fatal errors in the SDK instead of reporting the error.