### PR TITLE
Add the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+sudo: false
+
+php: [5.4, 5.5, 5.6, nightly, hhvm]
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+install:
+  - composer install
+
+script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.4",
-    "mockery/mockery": "dev-master"
+    "mockery/mockery": "~0.9"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This is it. All you have to do to have Travis running tests on your repo is to merge this file and enable Travis on the repo (this is a matter of switching a toggle in the Travis interface).

I changed the dependency on Mockery to allow using stable version, so that caching dependencies can be more efficient (Archives for stable versions will be cached between build once they can be downloaded once)